### PR TITLE
fix typos and add compatibility with lib performanceEstimation 1.1.0

### DIFF
--- a/R_Code/LM/AuxsIS.R
+++ b/R_Code/LM/AuxsIS.R
@@ -7,7 +7,7 @@
 WFnone <- function(form, train, test, learner, ...){ # workflow for using the original data set
   preds <- do.call(paste('cv', learner, sep='.'),
                    list(form, train,test, ...))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -15,7 +15,7 @@ WFRU <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.
   newtr <- RandUnderRegress(form, train, rel=rel, thr.rel=thr.rel, C.perc=C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,...))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -23,7 +23,7 @@ WFRO <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.
   newtr <- RandOverRegress(form, train, rel, thr.rel, C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,...))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -31,21 +31,21 @@ WFGN <- function(form, train, test, learner, rel, thr.rel, C.perc, pert, ...){
   newtr <- GaussNoiseRegress(form, train, rel, thr.rel, C.perc, pert)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,...))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFsmote <- function(form, train, test, learner, rel, thr.rel, C.perc, k, repl, dist, p, ...){
   newtr <- SmoteRegress(form, train, rel, thr.rel, C.perc, k, repl, dist, p)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,...))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFIS <- function(form, train, test, learner, rel, O, U, ...){
   newtr <- ImpSampRegress(form, train, rel=rel, thr.rel=NA, O, U)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,...))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -85,7 +85,7 @@ cv.nnet <- function(form, train, test,...){
 # metrics definition for the estimation task
 # ============================================================
 
-eval.stats <- function(trues,preds, stats, thr.rel, method,npts,control.pts,ymin,ymax,tloss,epsilon) {
+eval.stats <- function(trues,preds, stats, thr.rel, method,npts,control.pts,ymin,ymax,tloss,epsilon, ...) {
   pc <- list()
   pc$method <- method
   pc$npts <- npts

--- a/R_Code/LM/expsIS.R
+++ b/R_Code/LM/expsIS.R
@@ -59,7 +59,7 @@ for(d in 1:15){
 
 PCS <- list(PCSall[[1]], PCSall[[2]],PCSall[[3]], PCSall[[4]],PCSall[[5]],
             PCSall[[6]],PCSall[[7]],PCSall[[8]], PCSall[[9]], PCSall[[10]], 
-            PCSall[[11]]), PCSall[[12]], PCSall[[13]], PCSall[[14]], PCSall[[15]])
+            PCSall[[11]], PCSall[[12]], PCSall[[13]], PCSall[[14]], PCSall[[15]])
 
 myDSs <- list(PredTask(a1~., DSs[[1]]@data, "a1"), PredTask(a2~., DSs[[2]]@data, "a2"),
               PredTask(a3~., DSs[[3]]@data, "a3"), PredTask(a4~., DSs[[4]]@data, "a4"),

--- a/R_Code/MARS/AuxsIS.R
+++ b/R_Code/MARS/AuxsIS.R
@@ -7,25 +7,25 @@
 WFnone_earth_nk10_d1 <- function(form, train, test, learner){ # workflow for using the original data set
   preds <- do.call(paste('cv', learner, sep='.'),
                    list(form, train, test, nk=10, degree=1, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFnone_earth_nk10_d2 <- function(form, train, test, learner){ # workflow for using the original data set
   preds <- do.call(paste('cv', learner, sep='.'),
                    list(form, train, test, nk=10, degree=2, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFnone_earth_nk17_d1 <- function(form, train, test, learner){ # workflow for using the original data set
   preds <- do.call(paste('cv', learner, sep='.'),
                    list(form, train, test, nk=17, degree=1, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFnone_earth_nk17_d2 <- function(form, train, test, learner){ # workflow for using the original data set
   preds <- do.call(paste('cv', learner, sep='.'),
                    list(form, train, test, nk=17, degree=2, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -36,14 +36,14 @@ WFRU_earth_nk10_d1 <- function(form, train, test, learner, rel=rel, thr.rel=thr.
   newtr <- RandUnderRegress(form, train, rel=rel, thr.rel=thr.rel, C.perc=C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form, newtr, test, nk=10, degree=1, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFRU_earth_nk10_d2 <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.perc, ...){
   newtr <- RandUnderRegress(form, train, rel=rel, thr.rel=thr.rel, C.perc=C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form, newtr, test, nk=10, degree=2, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -51,7 +51,7 @@ WFRU_earth_nk17_d1 <- function(form, train, test, learner, rel=rel, thr.rel=thr.
   newtr <- RandUnderRegress(form, train, rel=rel, thr.rel=thr.rel, C.perc=C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form, newtr, test, nk=17, degree=1, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -59,7 +59,7 @@ WFRU_earth_nk17_d2 <- function(form, train, test, learner, rel=rel, thr.rel=thr.
   newtr <- RandUnderRegress(form, train, rel=rel, thr.rel=thr.rel, C.perc=C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form, newtr, test, nk=17, degree=2, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -67,28 +67,28 @@ WFRO_earth_nk10_d1 <- function(form, train, test, learner, rel=rel, thr.rel=thr.
   newtr <- RandOverRegress(form, train, rel, thr.rel, C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form, newtr, test, nk=10, degree=1, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFRO_earth_nk10_d2 <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.perc, ...){
   newtr <- RandOverRegress(form, train, rel, thr.rel, C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form, newtr, test, nk=10, degree=2, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFRO_earth_nk17_d1 <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.perc, ...){
   newtr <- RandOverRegress(form, train, rel, thr.rel, C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form, newtr, test, nk=17, degree=1, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFRO_earth_nk17_d2 <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.perc, ...){
   newtr <- RandOverRegress(form, train, rel, thr.rel, C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form, newtr, test, nk=17, degree=2, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -97,28 +97,28 @@ WFGN_earth_nk10_d1 <- function(form, train, test, learner, rel, thr.rel, C.perc,
   newtr <- GaussNoiseRegress(form, train, rel, thr.rel, C.perc, pert)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form, newtr, test, nk=10, degree=1, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFGN_earth_nk10_d2 <- function(form, train, test, learner, rel, thr.rel, C.perc, pert, ...){
   newtr <- GaussNoiseRegress(form, train, rel, thr.rel, C.perc, pert)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form, newtr, test, nk=10, degree=2, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFGN_earth_nk17_d1 <- function(form, train, test, learner, rel, thr.rel, C.perc, pert, ...){
   newtr <- GaussNoiseRegress(form, train, rel, thr.rel, C.perc, pert)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form, newtr, test, nk=17, degree=1, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFGN_earth_nk17_d2 <- function(form, train, test, learner, rel, thr.rel, C.perc, pert, ...){
   newtr <- GaussNoiseRegress(form, train, rel, thr.rel, C.perc, pert)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form, newtr, test, nk=17, degree=2, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -126,14 +126,14 @@ WFsmote_earth_nk10_d1 <- function(form, train, test, learner, rel, thr.rel, C.pe
   newtr <- SmoteRegress(form, train, rel, thr.rel, C.perc, k, repl, dist, p)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form, newtr, test, nk=10, degree=1, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFsmote_earth_nk10_d2 <- function(form, train, test, learner, rel, thr.rel, C.perc, k, repl, dist, p, ...){
   newtr <- SmoteRegress(form, train, rel, thr.rel, C.perc, k, repl, dist, p)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form, newtr, test, nk=10, degree=2, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -141,7 +141,7 @@ WFsmote_earth_nk17_d1 <- function(form, train, test, learner, rel, thr.rel, C.pe
   newtr <- SmoteRegress(form, train, rel, thr.rel, C.perc, k, repl, dist, p)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form, newtr, test, nk=17, degree=1, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -149,7 +149,7 @@ WFsmote_earth_nk17_d2 <- function(form, train, test, learner, rel, thr.rel, C.pe
   newtr <- SmoteRegress(form, train, rel, thr.rel, C.perc, k, repl, dist, p)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form, newtr, test, nk=17, degree=2, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -158,7 +158,7 @@ WFIS_earth_nk10_d1 <- function(form, train, test, learner, rel, O, U, ...){
   newtr <- ImpSampRegress(form, train, rel=rel, thr.rel=NA, O, U)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form, newtr, test, nk=10, degree=1, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -166,7 +166,7 @@ WFIS_earth_nk10_d2 <- function(form, train, test, learner, rel, O, U, ...){
   newtr <- ImpSampRegress(form, train, rel=rel, thr.rel=NA, O, U)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form, train, test, nk=10, degree=2, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -174,14 +174,14 @@ WFIS_earth_nk17_d1 <- function(form, train, test, learner, rel, O, U, ...){
   newtr <- ImpSampRegress(form, train, rel=rel, thr.rel=NA, O, U)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form, newtr, test, nk=17, degree=1, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFIS_earth_nk17_d2 <- function(form, train, test, learner, rel, O, U, ...){
   newtr <- ImpSampRegress(form, train, rel=rel, thr.rel=NA, O, U)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form, newtr, test, nk=17, degree=2, thresh=0.01))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -222,7 +222,7 @@ cv.nnet <- function(form, train, test,...){
 # metrics definition for the estimation task
 # ============================================================
 
-eval.stats <- function(trues,preds, stats, thr.rel, method,npts,control.pts,ymin,ymax,tloss,epsilon) {
+eval.stats <- function(trues,preds, stats, thr.rel, method,npts,control.pts,ymin,ymax,tloss,epsilon, ...) {
   pc <- list()
   pc$method <- method
   pc$npts <- npts

--- a/R_Code/MARS/expsIS.R
+++ b/R_Code/MARS/expsIS.R
@@ -58,7 +58,7 @@ for(d in 1:15){
 
 PCS <- list(PCSall[[1]], PCSall[[2]],PCSall[[3]], PCSall[[4]],PCSall[[5]],
             PCSall[[6]],PCSall[[7]],PCSall[[8]], PCSall[[9]], PCSall[[10]], 
-            PCSall[[11]]), PCSall[[12]], PCSall[[13]], PCSall[[14]], PCSall[[15]])
+            PCSall[[11]], PCSall[[12]], PCSall[[13]], PCSall[[14]], PCSall[[15]])
 
 myDSs <- list(PredTask(a1~., DSs[[1]]@data, "a1"), PredTask(a2~., DSs[[2]]@data, "a2"),
               PredTask(a3~., DSs[[3]]@data, "a3"), PredTask(a4~., DSs[[4]]@data, "a4"),

--- a/R_Code/NNET/AuxsIS.R
+++ b/R_Code/NNET/AuxsIS.R
@@ -7,52 +7,52 @@
 WFnone_nnet_s1_d0 <- function(form, train, test, learner){ # workflow for using the original data set
   preds <- do.call(paste('cv', learner, sep='.'),
                    list(form, train, test, size=1, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFnone_nnet_s2_d0 <- function(form, train, test, learner){ # workflow for using the original data set
   preds <- do.call(paste('cv', learner, sep='.'),
                    list(form, train, test, size=2, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
 WFnone_nnet_s5_d0 <- function(form, train, test, learner){ # workflow for using the original data set
   preds <- do.call(paste('cv', learner, sep='.'),
                    list(form, train,test, size=5, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFnone_nnet_s10_d0 <- function(form, train, test, learner){ # workflow for using the original data set
   preds <- do.call(paste('cv', learner, sep='.'),
                    list(form, train,test, size=10, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
 WFnone_nnet_s1_d0.01 <- function(form, train, test, learner){ # workflow for using the original data set
   preds <- do.call(paste('cv', learner, sep='.'),
                    list(form, train, test, size=1, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFnone_nnet_s2_d0.01 <- function(form, train, test, learner){ # workflow for using the original data set
   preds <- do.call(paste('cv', learner, sep='.'),
                    list(form, train, test, size=2, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
 WFnone_nnet_s5_d0.01 <- function(form, train, test, learner){ # workflow for using the original data set
   preds <- do.call(paste('cv', learner, sep='.'),
                    list(form, train,test, size=5, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFnone_nnet_s10_d0.01 <- function(form, train, test, learner){ # workflow for using the original data set
   preds <- do.call(paste('cv', learner, sep='.'),
                    list(form, train,test, size=10, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -61,49 +61,49 @@ WFRU_nnet_s1_d0 <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel
   newtr <- RandUnderRegress(form, train, rel=rel, thr.rel=thr.rel, C.perc=C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test, size=1, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 WFRU_nnet_s2_d0 <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.perc, ...){
   # C.p <- as.integer(length(which(train.rel>thr.rel))*0.25)*100/length(which(train.rel<=thr.rel))
   newtr <- RandUnderRegress(form, train, rel=rel, thr.rel=thr.rel, C.perc=C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test, size=2, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 WFRU_nnet_s5_d0 <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.perc, ...){
   # C.p <- as.integer(length(which(train.rel>thr.rel))*0.25)*100/length(which(train.rel<=thr.rel))
   newtr <- RandUnderRegress(form, train, rel=rel, thr.rel=thr.rel, C.perc=C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test, size=5, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 WFRU_nnet_s10_d0 <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.perc, ...){
   # C.p <- as.integer(length(which(train.rel>thr.rel))*0.25)*100/length(which(train.rel<=thr.rel))
   newtr <- RandUnderRegress(form, train, rel=rel, thr.rel=thr.rel, C.perc=C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test, size=10, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 WFRU_nnet_s1_d0.01 <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.perc, ...){
   # C.p <- as.integer(length(which(train.rel>thr.rel))*0.25)*100/length(which(train.rel<=thr.rel))
   newtr <- RandUnderRegress(form, train, rel=rel, thr.rel=thr.rel, C.perc=C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test, size=1, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 WFRU_nnet_s2_d0.01 <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.perc, ...){
   # C.p <- as.integer(length(which(train.rel>thr.rel))*0.25)*100/length(which(train.rel<=thr.rel))
   newtr <- RandUnderRegress(form, train, rel=rel, thr.rel=thr.rel, C.perc=C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test, size=2, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 WFRU_nnet_s5_d0.01 <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.perc, ...){
   # C.p <- as.integer(length(which(train.rel>thr.rel))*0.25)*100/length(which(train.rel<=thr.rel))
   newtr <- RandUnderRegress(form, train, rel=rel, thr.rel=thr.rel, C.perc=C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test, size=5, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFRU_nnet_s10_d0.01 <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.perc, ...){
@@ -111,7 +111,7 @@ WFRU_nnet_s10_d0.01 <- function(form, train, test, learner, rel=rel, thr.rel=thr
   newtr <- RandUnderRegress(form, train, rel=rel, thr.rel=thr.rel, C.perc=C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=10, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -119,55 +119,55 @@ WFRO_nnet_s1_d0 <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel
   newtr <- RandOverRegress(form, train, rel, thr.rel, C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=1, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFRO_nnet_s2_d0 <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.perc, ...){
   newtr <- RandOverRegress(form, train, rel, thr.rel, C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=2, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 WFRO_nnet_s5_d0 <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.perc, ...){
   newtr <- RandOverRegress(form, train, rel, thr.rel, C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=5, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFRO_nnet_s10_d0 <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.perc, ...){
   newtr <- RandOverRegress(form, train, rel, thr.rel, C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=10, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFRO_nnet_s1_d0.01 <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.perc, ...){
   newtr <- RandOverRegress(form, train, rel, thr.rel, C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test, size=1, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFRO_nnet_s2_d0.01 <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.perc, ...){
   newtr <- RandOverRegress(form, train, rel, thr.rel, C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test, size=2, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFRO_nnet_s5_d0.01 <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.perc, ...){
   newtr <- RandOverRegress(form, train, rel, thr.rel, C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test, size=5, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFRO_nnet_s10_d0.01 <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.perc, ...){
   newtr <- RandOverRegress(form, train, rel, thr.rel, C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test, size=10, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -175,142 +175,142 @@ WFGN_nnet_s1_d0 <- function(form, train, test, learner, rel, thr.rel, C.perc, pe
   newtr <- GaussNoiseRegress(form, train, rel, thr.rel, C.perc, pert)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=1, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFGN_nnet_s2_d0 <- function(form, train, test, learner, rel, thr.rel, C.perc, pert, ...){
   newtr <- GaussNoiseRegress(form, train, rel, thr.rel, C.perc, pert)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=2, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 WFGN_nnet_s5_d0 <- function(form, train, test, learner, rel, thr.rel, C.perc, pert, ...){
   newtr <- GaussNoiseRegress(form, train, rel, thr.rel, C.perc, pert)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=5, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 WFGN_nnet_s10_d0 <- function(form, train, test, learner, rel, thr.rel, C.perc, pert, ...){
   newtr <- GaussNoiseRegress(form, train, rel, thr.rel, C.perc, pert)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=10, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFGN_nnet_s1_d0.01 <- function(form, train, test, learner, rel, thr.rel, C.perc, pert, ...){
   newtr <- GaussNoiseRegress(form, train, rel, thr.rel, C.perc, pert)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=1, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFGN_nnet_s2_d0.01 <- function(form, train, test, learner, rel, thr.rel, C.perc, pert, ...){
   newtr <- GaussNoiseRegress(form, train, rel, thr.rel, C.perc, pert)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=2, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFGN_nnet_s5_d0.01 <- function(form, train, test, learner, rel, thr.rel, C.perc, pert, ...){
   newtr <- GaussNoiseRegress(form, train, rel, thr.rel, C.perc, pert)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=5, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFGN_nnet_s10_d0.01 <- function(form, train, test, learner, rel, thr.rel, C.perc, pert, ...){
   newtr <- GaussNoiseRegress(form, train, rel, thr.rel, C.perc, pert)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=10, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFsmote_nnet_s1_d0 <- function(form, train, test, learner, rel, thr.rel, C.perc, k, repl, dist, p, ...){
   newtr <- SmoteRegress(form, train, rel, thr.rel, C.perc, k, repl, dist, p)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=1, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFsmote_nnet_s2_d0 <- function(form, train, test, learner, rel, thr.rel, C.perc, k, repl, dist, p, ...){
   newtr <- SmoteRegress(form, train, rel, thr.rel, C.perc, k, repl, dist, p)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=2, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFsmote_nnet_s5_d0 <- function(form, train, test, learner, rel, thr.rel, C.perc, k, repl, dist, p, ...){
   newtr <- SmoteRegress(form, train, rel, thr.rel, C.perc, k, repl, dist, p)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=5, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFsmote_nnet_s10_d0 <- function(form, train, test, learner, rel, thr.rel, C.perc, k, repl, dist, p, ...){
   newtr <- SmoteRegress(form, train, rel, thr.rel, C.perc, k, repl, dist, p)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=10, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFsmote_nnet_s1_d0.01 <- function(form, train, test, learner, rel, thr.rel, C.perc, k, repl, dist, p, ...){
   newtr <- SmoteRegress(form, train, rel, thr.rel, C.perc, k, repl, dist, p)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=1, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFsmote_nnet_s2_d0.01 <- function(form, train, test, learner, rel, thr.rel, C.perc, k, repl, dist, p, ...){
   newtr <- SmoteRegress(form, train, rel, thr.rel, C.perc, k, repl, dist, p)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=2, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFsmote_nnet_s5_d0.01 <- function(form, train, test, learner, rel, thr.rel, C.perc, k, repl, dist, p, ...){
   newtr <- SmoteRegress(form, train, rel, thr.rel, C.perc, k, repl, dist, p)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=5, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 WFsmote_nnet_s10_d0.01 <- function(form, train, test, learner, rel, thr.rel, C.perc, k, repl, dist, p, ...){
   newtr <- SmoteRegress(form, train, rel, thr.rel, C.perc, k, repl, dist, p)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=10, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFIS_nnet_s1_d0 <- function(form, train, test, learner, rel, O, U, ...){
   newtr <- ImpSampRegress(form, train, rel=rel, thr.rel=NA, O, U)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=1, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFIS_nnet_s2_d0 <- function(form, train, test, learner, rel, O, U, ...){
   newtr <- ImpSampRegress(form, train, rel=rel, thr.rel=NA, O, U)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=2, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 WFIS_nnet_s5_d0 <- function(form, train, test, learner, rel, O, U, ...){
   newtr <- ImpSampRegress(form, train, rel=rel, thr.rel=NA, O, U)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=5, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 WFIS_nnet_s10_d0 <- function(form, train, test, learner, rel, O, U, ...){
   newtr <- ImpSampRegress(form, train, rel=rel, thr.rel=NA, O, U)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=10, decay=0,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFIS_nnet_s1_d0.01 <- function(form, train, test, learner, rel, O, U, ...){
   newtr <- ImpSampRegress(form, train, rel=rel, thr.rel=NA, O, U)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=1, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -318,19 +318,19 @@ WFIS_nnet_s2_d0.01 <- function(form, train, test, learner, rel, O, U, ...){
   newtr <- ImpSampRegress(form, train, rel=rel, thr.rel=NA, O, U)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=2, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 WFIS_nnet_s5_d0.01 <- function(form, train, test, learner, rel, O, U, ...){
   newtr <- ImpSampRegress(form, train, rel=rel, thr.rel=NA, O, U)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=5, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 WFIS_nnet_s10_d0.01 <- function(form, train, test, learner, rel, O, U, ...){
   newtr <- ImpSampRegress(form, train, rel=rel, thr.rel=NA, O, U)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,size=10, decay=0.01,linout=TRUE, skip=TRUE, MaxNWts=10000, trace=FALSE, maxit=100))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 # define the learn/test functions for the systems
@@ -371,7 +371,7 @@ cv.nnet <- function(form, train, test,...){
 # metrics definition for the estimation task
 # ============================================================
 
-eval.stats <- function(trues,preds, stats, thr.rel, method,npts,control.pts,ymin,ymax,tloss,epsilon) {
+eval.stats <- function(trues,preds, stats, thr.rel, method,npts,control.pts,ymin,ymax,tloss,epsilon, ...) {
   pc <- list()
   pc$method <- method
   pc$npts <- npts

--- a/R_Code/NNET/expsIS.R
+++ b/R_Code/NNET/expsIS.R
@@ -59,7 +59,7 @@ for(d in 1:15){
 
 PCS <- list(PCSall[[1]], PCSall[[2]],PCSall[[3]], PCSall[[4]],PCSall[[5]],
             PCSall[[6]],PCSall[[7]],PCSall[[8]], PCSall[[9]], PCSall[[10]], 
-            PCSall[[11]]), PCSall[[12]], PCSall[[13]], PCSall[[14]], PCSall[[15]])
+            PCSall[[11]], PCSall[[12]], PCSall[[13]], PCSall[[14]], PCSall[[15]])
 
 myDSs <- list(PredTask(a1~., DSs[[1]]@data, "a1"), PredTask(a2~., DSs[[2]]@data, "a2"),
               PredTask(a3~., DSs[[3]]@data, "a3"), PredTask(a4~., DSs[[4]]@data, "a4"),

--- a/R_Code/RF/AuxsIS.R
+++ b/R_Code/RF/AuxsIS.R
@@ -7,7 +7,7 @@
 WFnone <- function(form, train, test, learner, ...){ # workflow for using the original data set
   preds <- do.call(paste('cv', learner, sep='.'),
                    list(form, train,test, ...))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -15,7 +15,7 @@ WFRU <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.
   newtr <- RandUnderRegress(form, train, rel=rel, thr.rel=thr.rel, C.perc=C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,...))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -23,7 +23,7 @@ WFRO <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.
   newtr <- RandOverRegress(form, train, rel, thr.rel, C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,...))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -31,21 +31,21 @@ WFGN <- function(form, train, test, learner, rel, thr.rel, C.perc, pert, ...){
   newtr <- GaussNoiseRegress(form, train, rel, thr.rel, C.perc, pert)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,...))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFsmote <- function(form, train, test, learner, rel, thr.rel, C.perc, k, repl, dist, p, ...){
   newtr <- SmoteRegress(form, train, rel, thr.rel, C.perc, k, repl, dist, p)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,...))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFIS <- function(form, train, test, learner, rel, O, U, ...){
   newtr <- ImpSampRegress(form, train, rel=rel, thr.rel=NA, O, U)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,...))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -85,7 +85,7 @@ cv.nnet <- function(form, train, test,...){
 # metrics definition for the estimation task
 # ============================================================
 
-eval.stats <- function(trues,preds, stats, thr.rel, method,npts,control.pts,ymin,ymax,tloss,epsilon) {
+eval.stats <- function(trues,preds, stats, thr.rel, method,npts,control.pts,ymin,ymax,tloss,epsilon, ...) {
   pc <- list()
   pc$method <- method
   pc$npts <- npts

--- a/R_Code/RF/expsIS.R
+++ b/R_Code/RF/expsIS.R
@@ -59,7 +59,7 @@ for(d in 1:15){
 
 PCS <- list(PCSall[[1]], PCSall[[2]],PCSall[[3]], PCSall[[4]],PCSall[[5]],
             PCSall[[6]],PCSall[[7]],PCSall[[8]], PCSall[[9]], PCSall[[10]], 
-            PCSall[[11]]), PCSall[[12]], PCSall[[13]], PCSall[[14]], PCSall[[15]])
+            PCSall[[11]], PCSall[[12]], PCSall[[13]], PCSall[[14]], PCSall[[15]])
 
 myDSs <- list(PredTask(a1~., DSs[[1]]@data, "a1"), PredTask(a2~., DSs[[2]]@data, "a2"),
               PredTask(a3~., DSs[[3]]@data, "a3"), PredTask(a4~., DSs[[4]]@data, "a4"),

--- a/R_Code/SVM/AuxsIS.R
+++ b/R_Code/SVM/AuxsIS.R
@@ -7,7 +7,7 @@
 WFnone <- function(form, train, test, learner, ...){ # workflow for using the original data set
   preds <- do.call(paste('cv', learner, sep='.'),
                    list(form, train,test, ...))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -15,7 +15,7 @@ WFRU <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.
   newtr <- RandUnderRegress(form, train, rel=rel, thr.rel=thr.rel, C.perc=C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,...))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -23,7 +23,7 @@ WFRO <- function(form, train, test, learner, rel=rel, thr.rel=thr.rel, C.perc=C.
   newtr <- RandOverRegress(form, train, rel, thr.rel, C.perc)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,...))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -31,21 +31,21 @@ WFGN <- function(form, train, test, learner, rel, thr.rel, C.perc, pert, ...){
   newtr <- GaussNoiseRegress(form, train, rel, thr.rel, C.perc, pert)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,...))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFsmote <- function(form, train, test, learner, rel, thr.rel, C.perc, k, repl, dist, p, ...){
   newtr <- SmoteRegress(form, train, rel, thr.rel, C.perc, k, repl, dist, p)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,...))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 WFIS <- function(form, train, test, learner, rel, O, U, ...){
   newtr <- ImpSampRegress(form, train, rel=rel, thr.rel=NA, O, U)
   preds <- do.call(paste('cv',learner,sep='.'),
                    list(form,newtr,test,...))
-  WFoutput(rownames(test),responseValues(form,test),preds)
+  list(trues=responseValues(form,test),preds=preds)
 }
 
 
@@ -85,7 +85,7 @@ cv.nnet <- function(form, train, test,...){
 # metrics definition for the estimation task
 # ============================================================
 
-eval.stats <- function(trues,preds, stats, thr.rel, method,npts,control.pts,ymin,ymax,tloss,epsilon) {
+eval.stats <- function(trues,preds, stats, thr.rel, method,npts,control.pts,ymin,ymax,tloss,epsilon, ...) {
   pc <- list()
   pc$method <- method
   pc$npts <- npts

--- a/R_Code/SVM/expsIS.R
+++ b/R_Code/SVM/expsIS.R
@@ -59,7 +59,7 @@ for(d in 1:15){
 
 PCS <- list(PCSall[[1]], PCSall[[2]],PCSall[[3]], PCSall[[4]],PCSall[[5]],
             PCSall[[6]],PCSall[[7]],PCSall[[8]], PCSall[[9]], PCSall[[10]], 
-            PCSall[[11]]), PCSall[[12]], PCSall[[13]], PCSall[[14]], PCSall[[15]])
+            PCSall[[11]], PCSall[[12]], PCSall[[13]], PCSall[[14]], PCSall[[15]])
 
 myDSs <- list(PredTask(a1~., DSs[[1]]@data, "a1"), PredTask(a2~., DSs[[2]]@data, "a2"),
               PredTask(a3~., DSs[[3]]@data, "a3"), PredTask(a4~., DSs[[4]]@data, "a4"),


### PR DESCRIPTION
In the current version of R some functions of the library “performanceEstimation” had to be updated. 
Additionally in the code there was a breaking error in the block data set declaration, that was fixed. 
Function evaluation stats was fixed to support current version of the R.
